### PR TITLE
リリース / v0.10.1

### DIFF
--- a/MusicerBeat/Models/SequentialSelector.cs
+++ b/MusicerBeat/Models/SequentialSelector.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace MusicerBeat.Models
 {
@@ -21,7 +22,12 @@ namespace MusicerBeat.Models
         #nullable enable
         public SoundFile? SelectSoundFile()
         {
-            if (SoundFiles.Count == 0)
+            if (SoundFiles.Count == 0 && SoundFiles.All(s => s.IsSkip))
+            {
+                return null;
+            }
+
+            if (!IsLoop && SoundFiles.Skip(Index).All(s => s.IsSkip))
             {
                 return null;
             }
@@ -34,11 +40,16 @@ namespace MusicerBeat.Models
                 }
 
                 Index = 0;
-                return SoundFiles[Index++];
             }
 
-            Index = Math.Min(Index, SoundFiles.Count - 1);
-            return SoundFiles[Index++];
+            var idx = SoundFiles.ToList().FindIndex(Index, s => !s.IsSkip);
+            if (idx == -1)
+            {
+                idx = SoundFiles.ToList().FindIndex(s => !s.IsSkip);
+            }
+
+            Index = idx + 1;
+            return SoundFiles[idx];
         }
 
         /// <summary>

--- a/MusicerBeat/Models/SoundFile.cs
+++ b/MusicerBeat/Models/SoundFile.cs
@@ -14,6 +14,7 @@ namespace MusicerBeat.Models
         private int listenCount;
         private bool isSkip;
         private bool playing;
+        private string nameWithoutExtension;
 
         public SoundFile(string filePath)
         {
@@ -24,12 +25,19 @@ namespace MusicerBeat.Models
 
             FullName = filePath;
             Name = Path.GetFileName(filePath);
+            NameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
             Extension = Path.GetExtension(filePath).ToLower();
         }
 
         public string FullName { get => fullName; set => SetProperty(ref fullName, value); }
 
         public string Name { get => name; set => SetProperty(ref name, value); }
+
+        public string NameWithoutExtension
+        {
+            get => nameWithoutExtension;
+            set => SetProperty(ref nameWithoutExtension, value);
+        }
 
         public string Extension { get; set; }
 

--- a/MusicerBeat/Models/SoundFile.cs
+++ b/MusicerBeat/Models/SoundFile.cs
@@ -15,6 +15,7 @@ namespace MusicerBeat.Models
         private bool isSkip;
         private bool playing;
         private string nameWithoutExtension;
+        private int index;
 
         public SoundFile(string filePath)
         {
@@ -48,6 +49,8 @@ namespace MusicerBeat.Models
         public bool IsSkip { get => isSkip; set => SetProperty(ref isSkip, value); }
 
         public bool Playing { get => playing; set => SetProperty(ref playing, value); }
+
+        public int Index { get => index; set => SetProperty(ref index, value); }
 
         public static bool IsSoundFile(string filePath)
         {

--- a/MusicerBeat/Models/SoundStorage.cs
+++ b/MusicerBeat/Models/SoundStorage.cs
@@ -18,6 +18,7 @@ namespace MusicerBeat.Models
             {
                 if (SetProperty(ref fullPath, value))
                 {
+                    IsM3U = Path.GetExtension(fullPath)?.ToLower() == ".m3u";
                     RaisePropertyChanged(nameof(Name));
                 }
             }
@@ -29,13 +30,32 @@ namespace MusicerBeat.Models
             private set => SetProperty(ref name, value);
         }
 
+        public bool IsM3U { get; set; }
+
         public IEnumerable<SoundStorage> GetChildren()
         {
-            return Directory.GetDirectories(FullPath).Select(d => new SoundStorage() { FullPath = d, });
+            var list = new List<SoundStorage>();
+            if (!Directory.Exists(FullPath))
+            {
+                return list;
+            }
+
+            list.AddRange(Directory.GetDirectories(FullPath).Select(d => new SoundStorage() { FullPath = d, }));
+            list.AddRange(
+                Directory.GetFiles(FullPath)
+                    .Where(s => Path.GetExtension(s).ToLower() == ".m3u")
+                    .Select(s => new SoundStorage() { FullPath = s, }));
+
+            return list;
         }
 
         public IEnumerable<SoundFile> GetFiles()
         {
+            if (IsM3U)
+            {
+                return ParseM3U(File.ReadAllText(FullPath));
+            }
+
             return Directory.GetFiles(FullPath)
                 .Where(SoundFile.IsSoundFile)
                 .Select(d =>

--- a/MusicerBeat/Models/SoundStorage.cs
+++ b/MusicerBeat/Models/SoundStorage.cs
@@ -30,7 +30,7 @@ namespace MusicerBeat.Models
             private set => SetProperty(ref name, value);
         }
 
-        public bool IsM3U { get; set; }
+        private bool IsM3U { get; set; }
 
         public IEnumerable<SoundStorage> GetChildren()
         {

--- a/MusicerBeat/Models/SoundStorage.cs
+++ b/MusicerBeat/Models/SoundStorage.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -44,6 +45,16 @@ namespace MusicerBeat.Models
                     return sf;
                 })
                 .OrderBy(f => f.Name);
+        }
+
+        public List<SoundFile> ParseM3U(string text)
+        {
+            string[] newLineStrings = { "\r\n", "\n", "\r", };
+
+            return text.Split(newLineStrings, StringSplitOptions.RemoveEmptyEntries)
+                .Where(l => !l.TrimStart().StartsWith("#"))
+                .Select(l => new SoundFile(l))
+                .ToList();
         }
     }
 }

--- a/MusicerBeat/Models/TextWrapper.cs
+++ b/MusicerBeat/Models/TextWrapper.cs
@@ -30,9 +30,9 @@ namespace MusicerBeat.Models
         private void SetVersion()
         {
             const int major = 0;
-            const int minor = 9;
+            const int minor = 10;
             const int patch = 1;
-            const string date = "20250224";
+            const string date = "20250225";
             const string suffixId = "a";
 
             Version = $"{major}.{minor}.{patch} ({date}{suffixId})";

--- a/MusicerBeat/ViewModels/SoundListViewModel.cs
+++ b/MusicerBeat/ViewModels/SoundListViewModel.cs
@@ -18,6 +18,11 @@ namespace MusicerBeat.ViewModels
             {
                 originalSounds.Clear();
                 originalSounds.AddRange(soundCollectionSource.GetSounds());
+
+                for (var i = 0; i < originalSounds.Count; i++)
+                {
+                    originalSounds[i].Index = i + 1;
+                }
             };
 
             Sounds = new ReadOnlyObservableCollection<SoundFile>(originalSounds);

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -95,7 +95,7 @@
                         <TextBlock
                             Grid.Column="1"
                             Margin="5,0"
-                            Text="{Binding Name}" />
+                            Text="{Binding NameWithoutExtension}" />
 
                     </Grid>
                 </DataTemplate>

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -82,18 +82,27 @@
                         </Grid.InputBindings>
 
                         <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="40" />
+                            <ColumnDefinition Width="30" />
                             <ColumnDefinition />
                         </Grid.ColumnDefinitions>
+
                         <Border
                             Grid.Column="0"
                             BorderBrush="Gray"
                             BorderThickness="0,0,1,0">
-                            <TextBlock Width="15" Text="{Binding ListenCount}" />
+                            <TextBlock Text="{Binding Index, StringFormat={}{0:D3}}" />
+                        </Border>
+
+                        <Border
+                            Grid.Column="1"
+                            BorderBrush="Gray"
+                            BorderThickness="0,0,1,0">
+                            <TextBlock Padding="3,0" Text="{Binding ListenCount}" />
                         </Border>
 
                         <TextBlock
-                            Grid.Column="1"
+                            Grid.Column="2"
                             Margin="5,0"
                             Text="{Binding NameWithoutExtension}" />
 

--- a/MusicerBeatTests/Models/SequentialSelectorTest.cs
+++ b/MusicerBeatTests/Models/SequentialSelectorTest.cs
@@ -49,6 +49,33 @@ namespace MusicerBeatTests.Models
         }
 
         [Test]
+        public void SelectSoundFile_Contains_SkipFile()
+        {
+            var list = new ObservableCollection<SoundFile>()
+            {
+                new ("C://t/a.mp3"),
+                new ("C://t/b.mp3"),
+                new ("C://t/c.mp3") {IsSkip = true, },
+            };
+
+            var s = new SequentialSelector(new ReadOnlyObservableCollection<SoundFile>(list))
+            {
+                IsLoop = false,
+            };
+
+            var expected = new[] { "a.mp3", "b.mp3", null, };
+
+            var results = new []
+            {
+                s.SelectSoundFile()?.Name,
+                s.SelectSoundFile()?.Name,
+                s.SelectSoundFile()?.Name,
+            };
+
+            CollectionAssert.AreEqual(expected, results);
+        }
+
+        [Test]
         public void SetIndexBySoundFile_Test()
         {
             var list = new ObservableCollection<SoundFile>()

--- a/MusicerBeatTests/Models/SequentialSelectorTest.cs
+++ b/MusicerBeatTests/Models/SequentialSelectorTest.cs
@@ -48,15 +48,9 @@ namespace MusicerBeatTests.Models
             CollectionAssert.AreEqual(expected, results);
         }
 
-        private static IEnumerable<
-            (
-            List<SoundFile> SoundFiles,
-            List<string> ExpectedFileNames,
-            bool loopFlag
-            )> SequentialSelectorCases()
+        private static IEnumerable<TestCaseData> SequentialSelectorCases()
         {
-            yield return
-            (
+            yield return new TestCaseData(
                 new List<SoundFile>
                 {
                     new (@"C:\t\a.mp3"){ IsSkip = false, },
@@ -65,10 +59,9 @@ namespace MusicerBeatTests.Models
                 },
                 new List<string> { "a.mp3", "b.mp3", "c.mp3", },
                 false
-            );
+            ).SetName("スキップなしの通常再生");
 
-            yield return
-            (
+            yield return new TestCaseData(
                 new List<SoundFile>
                 {
                     new (@"C:\t\a.mp3"){ IsSkip = true, },
@@ -77,10 +70,9 @@ namespace MusicerBeatTests.Models
                 },
                 new List<string> { "b.mp3", "c.mp3", null, },
                 false
-            );
+            ).SetName("最初の曲をスキップ");
 
-            yield return
-            (
+            yield return new TestCaseData(
                 new List<SoundFile>
                 {
                     new (@"C:\t\a.mp3"){ IsSkip = false, },
@@ -89,10 +81,9 @@ namespace MusicerBeatTests.Models
                 },
                 new List<string> { "a.mp3", "c.mp3", null, },
                 false
-            );
+            ).SetName("真ん中にある曲をスキップ");
 
-            yield return
-            (
+            yield return new TestCaseData(
                 new List<SoundFile>
                 {
                     new (@"C:\t\a.mp3"){ IsSkip = false, },
@@ -101,10 +92,9 @@ namespace MusicerBeatTests.Models
                 },
                 new List<string> { "a.mp3", "b.mp3", null, },
                 false
-            );
+            ).SetName("最後の曲をスキップ");
 
-            yield return
-            (
+            yield return new TestCaseData(
                 new List<SoundFile>
                 {
                     new (@"C:\t\a.mp3"){ IsSkip = false, },
@@ -113,10 +103,9 @@ namespace MusicerBeatTests.Models
                 },
                 new List<string> { "a.mp3", "b.mp3", "a.mp3", },
                 true
-            );
+            ).SetName("最後の曲をスキップ(ループ)");
 
-            yield return
-            (
+            yield return new TestCaseData(
                 new List<SoundFile>
                 {
                     new (@"C:\t\a.mp3"){ IsSkip = true, },
@@ -125,20 +114,19 @@ namespace MusicerBeatTests.Models
                 },
                 new List<string> { "b.mp3", "c.mp3", "b.mp3", },
                 true
-            );
+            ).SetName("最初の曲をスキップ(ループ)");
         }
 
         [TestCaseSource(nameof(SequentialSelectorCases))]
-        public void SelectSoundFile_Tests((
-            List<SoundFile> SoundFiles,
-            List<string> ExpectedFileNames,
-            bool loopFlag
-            ) testData)
+        public void SelectSoundFile_Tests(
+            List<SoundFile> soundFiles,
+            List<string> expectedFileNames,
+            bool loopFlag)
         {
-            var list = new ObservableCollection<SoundFile>(testData.SoundFiles);
+            var list = new ObservableCollection<SoundFile>(soundFiles);
             var s = new SequentialSelector(new ReadOnlyObservableCollection<SoundFile>(list))
             {
-                IsLoop = testData.loopFlag,
+                IsLoop = loopFlag,
             };
 
             var results = new []
@@ -148,7 +136,7 @@ namespace MusicerBeatTests.Models
                 s.SelectSoundFile()?.Name,
             };
 
-            CollectionAssert.AreEqual(testData.ExpectedFileNames, results);
+            CollectionAssert.AreEqual(expectedFileNames, results);
         }
 
         [Test]

--- a/MusicerBeatTests/Models/SequentialSelectorTest.cs
+++ b/MusicerBeatTests/Models/SequentialSelectorTest.cs
@@ -48,6 +48,109 @@ namespace MusicerBeatTests.Models
             CollectionAssert.AreEqual(expected, results);
         }
 
+        private static IEnumerable<
+            (
+            List<SoundFile> SoundFiles,
+            List<string> ExpectedFileNames,
+            bool loopFlag
+            )> SequentialSelectorCases()
+        {
+            yield return
+            (
+                new List<SoundFile>
+                {
+                    new (@"C:\t\a.mp3"){ IsSkip = false, },
+                    new (@"C:\t\b.mp3"){ IsSkip = false, },
+                    new (@"C:\t\c.mp3"){ IsSkip = false, },
+                },
+                new List<string> { "a.mp3", "b.mp3", "c.mp3", },
+                false
+            );
+
+            yield return
+            (
+                new List<SoundFile>
+                {
+                    new (@"C:\t\a.mp3"){ IsSkip = true, },
+                    new (@"C:\t\b.mp3"){ IsSkip = false, },
+                    new (@"C:\t\c.mp3"){ IsSkip = false, },
+                },
+                new List<string> { "b.mp3", "c.mp3", null, },
+                false
+            );
+
+            yield return
+            (
+                new List<SoundFile>
+                {
+                    new (@"C:\t\a.mp3"){ IsSkip = false, },
+                    new (@"C:\t\b.mp3"){ IsSkip = true, },
+                    new (@"C:\t\c.mp3"){ IsSkip = false, },
+                },
+                new List<string> { "a.mp3", "c.mp3", null, },
+                false
+            );
+
+            yield return
+            (
+                new List<SoundFile>
+                {
+                    new (@"C:\t\a.mp3"){ IsSkip = false, },
+                    new (@"C:\t\b.mp3"){ IsSkip = false, },
+                    new (@"C:\t\c.mp3"){ IsSkip = true, },
+                },
+                new List<string> { "a.mp3", "b.mp3", null, },
+                false
+            );
+
+            yield return
+            (
+                new List<SoundFile>
+                {
+                    new (@"C:\t\a.mp3"){ IsSkip = false, },
+                    new (@"C:\t\b.mp3"){ IsSkip = false, },
+                    new (@"C:\t\c.mp3"){ IsSkip = true, },
+                },
+                new List<string> { "a.mp3", "b.mp3", "a.mp3", },
+                true
+            );
+
+            yield return
+            (
+                new List<SoundFile>
+                {
+                    new (@"C:\t\a.mp3"){ IsSkip = true, },
+                    new (@"C:\t\b.mp3"){ IsSkip = false, },
+                    new (@"C:\t\c.mp3"){ IsSkip = false, },
+                },
+                new List<string> { "b.mp3", "c.mp3", "b.mp3", },
+                true
+            );
+        }
+
+        [TestCaseSource(nameof(SequentialSelectorCases))]
+        public void SelectSoundFile_Tests((
+            List<SoundFile> SoundFiles,
+            List<string> ExpectedFileNames,
+            bool loopFlag
+            ) testData)
+        {
+            var list = new ObservableCollection<SoundFile>(testData.SoundFiles);
+            var s = new SequentialSelector(new ReadOnlyObservableCollection<SoundFile>(list))
+            {
+                IsLoop = testData.loopFlag,
+            };
+
+            var results = new []
+            {
+                s.SelectSoundFile()?.Name,
+                s.SelectSoundFile()?.Name,
+                s.SelectSoundFile()?.Name,
+            };
+
+            CollectionAssert.AreEqual(testData.ExpectedFileNames, results);
+        }
+
         [Test]
         public void SelectSoundFile_Contains_SkipFile()
         {

--- a/MusicerBeatTests/Models/SoundStorageTests.cs
+++ b/MusicerBeatTests/Models/SoundStorageTests.cs
@@ -1,0 +1,43 @@
+using MusicerBeat.Models;
+
+namespace MusicerBeatTests.Models
+{
+    [TestFixture]
+    public class SoundStorageTests
+    {
+        private static IEnumerable<TestCaseData> ParseM3U_TestCases()
+        {
+            yield return new TestCaseData(
+                @"C:\\t\a.mp3" + "\r\n" +
+                @"C:\\t\b.mp3" + "\r\n" +
+                @"C:\\t\c.mp3" + "\r\n",
+                new[] { @"C:\\t\a.mp3", @"C:\\t\b.mp3", @"C:\\t\c.mp3", }
+            ).SetName("基本的なM3Uファイルのパース");
+
+            yield return new TestCaseData(
+                @"C:\\music\song1.mp3" + "\r\n" +
+                @"C:\\music\song2.mp3",
+                new[] { @"C:\\music\song1.mp3", @"C:\\music\song2.mp3", }
+            ).SetName("2つのエントリだけのM3U");
+
+            yield return new TestCaseData(
+                @" # C:\\music\song1.mp3" + "\r\n" +
+                @"C:\\music\song2.mp3",
+                new[] { @"C:\\music\song2.mp3", }
+            ).SetName("コメントアウトを含むM3U");
+
+            yield return new TestCaseData(
+                "", Array.Empty<string>()
+            ).SetName("空のM3U");
+        }
+
+        [TestCaseSource(nameof(ParseM3U_TestCases))]
+        public void ParseM3u_Test(string m3UData, string[] expected)
+        {
+            var storage = new SoundStorage();
+            var results = storage.ParseM3U(m3UData).Select(s => s.FullName);
+
+            CollectionAssert.AreEqual(expected, results);
+        }
+    }
+}

--- a/MusicerBeatTests/ViewModels/PlaybackControlViewModelTest.cs
+++ b/MusicerBeatTests/ViewModels/PlaybackControlViewModelTest.cs
@@ -138,9 +138,28 @@ namespace MusicerBeatTests.ViewModels
                     (TimeSpan.FromMilliseconds(250), 0, 1.0, "p1, p2 (4) クロスフェード完了"),
 
                     (TimeSpan.FromMilliseconds(500), 1.0, null, "p2 + 500ms"),
-                    (TimeSpan.FromMilliseconds(500), 1.0, null, "p2 end, p3 + 500ms"),
-                    (TimeSpan.FromMilliseconds(1000), 1.0, null, "p3 end, p4 + 1000ms"),
+                    (TimeSpan.FromMilliseconds(500), 1.0, null, "p2 end"),
+                    (TimeSpan.FromMilliseconds(1000), 1.0, null, "p3 end"),
+                    (TimeSpan.FromMilliseconds(1000), 1.0, null, "p4 + 1000ms"),
                     (TimeSpan.FromMilliseconds(1000), 1.0, null, "p4 end,"),
+                }
+            );
+
+            yield return (
+                new List<(string, int, string)>
+                {
+                    (@"C:\test\a.mp3", 1, "p1"),
+                    (@"C:\test\b.mp3", 1, "p2"),
+                    (@"C:\test\c.mp3", 1, "p3"),
+                },
+                new List<(TimeSpan, double?, double?, string)>
+                {
+                    (TimeSpan.FromMilliseconds(500), 1.0, null, "p1-1"),
+                    (TimeSpan.FromMilliseconds(500), 1.0, null, "p1-2"),
+                    (TimeSpan.FromMilliseconds(500), 1.0, null, "p2-1"),
+                    (TimeSpan.FromMilliseconds(500), 1.0, null, "p2-2"),
+                    (TimeSpan.FromMilliseconds(500), 1.0, null, "p3-1"),
+                    (TimeSpan.FromMilliseconds(500), 1.0, null, "p3-2"),
                 }
             );
         }
@@ -200,7 +219,8 @@ namespace MusicerBeatTests.ViewModels
                     }
                 });
 
-                soundPlayerFactory.PlayerSource.ForEach(p => p.CurrentTime += time);
+                var r = Enumerable.Reverse(soundPlayerFactory.PlayerSource).ToList();
+                r.ForEach(p => p.CurrentTime += time);
             }
 
             // 全ての再生が終了したはずなので、プレイヤーが停止状態かを確認する。


### PR DESCRIPTION
 - 機能追加
     - SequentialSelector をスキップ対応にした。
     - m3u ファイルからサウンドファイルリストを読み込む機能を実装した。
 - 外観
     - サウンドファイルリストのアイテムの番号を表示。
     - サウンドファイルリストのアイテムの表示名から拡張子を除外。
 - テスト
     - PlaybackControlViewModel の音量変遷のテストの追加・拡充。
     - SequentialSelector のテストの追加・拡充。