### PR TITLE
リリース / v0.16.0

### DIFF
--- a/MusicerBeat/Models/Databases/SoundFileService.cs
+++ b/MusicerBeat/Models/Databases/SoundFileService.cs
@@ -83,7 +83,7 @@ namespace MusicerBeat.Models.Databases
             {
                 if (dic.TryGetValue(soundFile.FullName, out var s))
                 {
-                    results.Add((s.ListenCount, s.TotalSeconds));
+                    results.Add((s.ListenCount, s.TotalMilliSeconds));
                 }
             }
 
@@ -103,7 +103,7 @@ namespace MusicerBeat.Models.Databases
                 }
 
                 soundFile.ListenCount = s.ListenCount;
-                soundFile.TotalSeconds = s.TotalSeconds;
+                soundFile.TotalMilliSeconds = s.TotalMilliSeconds;
             }
         }
     }

--- a/MusicerBeat/Models/IntToTimeSpanConverter.cs
+++ b/MusicerBeat/Models/IntToTimeSpanConverter.cs
@@ -9,7 +9,7 @@ namespace MusicerBeat.Models
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             var intValue = value != null ? (int)value : 0;
-            return TimeSpan.FromSeconds(intValue).ToString("h':'mm':'ss");
+            return TimeSpan.FromMilliseconds(intValue).ToString("h':'mm':'ss");
         }
 
         public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/MusicerBeat/Models/SequentialSelector.cs
+++ b/MusicerBeat/Models/SequentialSelector.cs
@@ -80,7 +80,7 @@ namespace MusicerBeat.Models
             var sound = SelectSoundFile();
             Index = originalIndex;
 
-            return sound != null && TimeSpan.FromSeconds(sound.TotalSeconds) >= threshold;
+            return sound != null && TimeSpan.FromSeconds(sound.TotalMilliSeconds) >= threshold;
         }
     }
 }

--- a/MusicerBeat/Models/SequentialSelector.cs
+++ b/MusicerBeat/Models/SequentialSelector.cs
@@ -80,7 +80,7 @@ namespace MusicerBeat.Models
             var sound = SelectSoundFile();
             Index = originalIndex;
 
-            return sound != null && TimeSpan.FromSeconds(sound.TotalMilliSeconds) >= threshold;
+            return sound != null && TimeSpan.FromMilliseconds(sound.TotalMilliSeconds) >= threshold;
         }
     }
 }

--- a/MusicerBeat/Models/Services/SoundPlayerMixer.cs
+++ b/MusicerBeat/Models/Services/SoundPlayerMixer.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MusicerBeat.Models.Interfaces;
+
+namespace MusicerBeat.Models.Services
+{
+    public class SoundPlayerMixer
+    {
+        public SoundPlayerMixer(ISoundPlayerFactory soundPlayerFactory)
+        {
+            SoundPlayerFactory = soundPlayerFactory;
+        }
+
+        private List<ISoundPlayer> SoundPlayers { get; set; }
+
+        private ISoundPlayerFactory SoundPlayerFactory { get; }
+
+        public PlayingStatus GetStatus()
+        {
+            if (SoundPlayers.Count == 0)
+            {
+                return PlayingStatus.Stopped;
+            }
+
+            if (SoundPlayers.Count == 1)
+            {
+                if (!SoundPlayers.First().IsPlaying)
+                {
+                    throw new InvalidOperationException("Invalid Status");
+                }
+
+                return PlayingStatus.Playing;
+            }
+
+            if (SoundPlayers.Count == 2)
+            {
+                if (SoundPlayers.All(p => p.IsPlaying))
+                {
+                    // リストの中のプレイヤーが両方動いている。
+                    return PlayingStatus.Fading;
+                }
+            }
+
+            throw new InvalidOperationException("Invalid Status");
+        }
+
+        private void Play(SoundFile soundFile)
+        {
+            var newPlayer = SoundPlayerFactory.CreateSoundPlayer();
+            newPlayer.SoundEnded += RemoveAndPlay;
+            SoundPlayers.Add(newPlayer);
+            newPlayer.PlaySound(soundFile);
+
+            newPlayer.Volume = GetStatus() switch
+            {
+                PlayingStatus.Playing => 1.0f,
+                PlayingStatus.Fading => 0f,
+                _ => newPlayer.Volume,
+            };
+        }
+
+        private void RemoveAndPlay(object sender, EventArgs e)
+        {
+            if (sender is ISoundPlayer p)
+            {
+                SoundPlayers.Remove(p);
+            }
+
+            if (GetStatus() == PlayingStatus.Stopped)
+            {
+                Play(null);
+            }
+        }
+    }
+}

--- a/MusicerBeat/Models/Services/SoundPlayerMixer.cs
+++ b/MusicerBeat/Models/Services/SoundPlayerMixer.cs
@@ -18,6 +18,11 @@ namespace MusicerBeat.Models.Services
             SoundPlayerFactory = soundPlayerFactory;
         }
 
+        /// <summary>
+        /// このインスタンスが保持するプレイヤーの再生が終了した時に発生するイベントです。
+        /// </summary>
+        public event EventHandler SoundEnded;
+
         private List<ISoundPlayer> SoundPlayers { get; }
 
         private ISoundPlayerFactory SoundPlayerFactory { get; }
@@ -51,7 +56,12 @@ namespace MusicerBeat.Models.Services
             throw new InvalidOperationException("Invalid Status");
         }
 
-        private void Play(SoundFile soundFile)
+        /// <summary>
+        /// 入力された `SoundFile` を使って再生を開始します。<br/>
+        /// このメソッドにより再生を開始した場合、プレイヤーの初期音量はこのインスタンスの内部状態によって適宜調整されます。
+        /// </summary>
+        /// <param name="soundFile">再生する `SoundFile` を入力します。</param>
+        public void Play(SoundFile soundFile)
         {
             var newPlayer = SoundPlayerFactory.CreateSoundPlayer();
             newPlayer.SoundEnded += RemoveAndPlay;
@@ -87,10 +97,7 @@ namespace MusicerBeat.Models.Services
                 SoundPlayers.Remove(p);
             }
 
-            if (GetStatus() == PlayingStatus.Stopped)
-            {
-                Play(null);
-            }
+            SoundEnded?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/MusicerBeat/Models/Services/SoundPlayerMixer.cs
+++ b/MusicerBeat/Models/Services/SoundPlayerMixer.cs
@@ -66,6 +66,20 @@ namespace MusicerBeat.Models.Services
             };
         }
 
+        public void Stop()
+        {
+            foreach (var p in SoundPlayers)
+            {
+                p.Stop();
+                if (p is IDisposable d)
+                {
+                    d.Dispose();
+                }
+            }
+
+            SoundPlayers.Clear();
+        }
+
         private void RemoveAndPlay(object sender, EventArgs e)
         {
             if (sender is ISoundPlayer p)

--- a/MusicerBeat/Models/Services/SoundPlayerMixer.cs
+++ b/MusicerBeat/Models/Services/SoundPlayerMixer.cs
@@ -7,12 +7,18 @@ namespace MusicerBeat.Models.Services
 {
     public class SoundPlayerMixer
     {
-        public SoundPlayerMixer(ISoundPlayerFactory soundPlayerFactory)
+        /// <summary>
+        /// SoundPlayerMixer をインスタンス化するコンストラクタです。
+        /// </summary>
+        /// <param name="soundPlayers">入力されたリストは内部で参照が保持され、`SoundPlayer` が生成された際に新しいプレイヤーを追加します。</param>
+        /// <param name="soundPlayerFactory">このクラスの内部で `ISoundPlayer` を生成するファクトリークラスを入力します。</param>
+        public SoundPlayerMixer(List<ISoundPlayer> soundPlayers, ISoundPlayerFactory soundPlayerFactory)
         {
+            SoundPlayers = soundPlayers;
             SoundPlayerFactory = soundPlayerFactory;
         }
 
-        private List<ISoundPlayer> SoundPlayers { get; set; }
+        private List<ISoundPlayer> SoundPlayers { get; }
 
         private ISoundPlayerFactory SoundPlayerFactory { get; }
 

--- a/MusicerBeat/Models/Services/SoundPlayerMixer.cs
+++ b/MusicerBeat/Models/Services/SoundPlayerMixer.cs
@@ -64,7 +64,7 @@ namespace MusicerBeat.Models.Services
         public void Play(SoundFile soundFile)
         {
             var newPlayer = SoundPlayerFactory.CreateSoundPlayer();
-            newPlayer.SoundEnded += RemoveAndPlay;
+            newPlayer.SoundEnded += RemovePlayer;
             SoundPlayers.Add(newPlayer);
             newPlayer.PlaySound(soundFile);
 
@@ -90,7 +90,7 @@ namespace MusicerBeat.Models.Services
             SoundPlayers.Clear();
         }
 
-        private void RemoveAndPlay(object sender, EventArgs e)
+        private void RemovePlayer(object sender, EventArgs e)
         {
             if (sender is ISoundPlayer p)
             {

--- a/MusicerBeat/Models/Services/SoundPlayerMixer.cs
+++ b/MusicerBeat/Models/Services/SoundPlayerMixer.cs
@@ -27,6 +27,8 @@ namespace MusicerBeat.Models.Services
 
         private ISoundPlayerFactory SoundPlayerFactory { get; }
 
+        public float DefaultVolume { private get; set; } = 1.0f;
+
         public PlayingStatus GetStatus()
         {
             if (SoundPlayers.Count == 0)
@@ -70,7 +72,7 @@ namespace MusicerBeat.Models.Services
 
             newPlayer.Volume = GetStatus() switch
             {
-                PlayingStatus.Playing => 1.0f,
+                PlayingStatus.Playing => DefaultVolume,
                 PlayingStatus.Fading => 0f,
                 _ => newPlayer.Volume,
             };

--- a/MusicerBeat/Models/SoundFile.cs
+++ b/MusicerBeat/Models/SoundFile.cs
@@ -79,12 +79,12 @@ namespace MusicerBeat.Models
             if (Extension == ".ogg")
             {
                 using var vr = new VorbisReader(FullName);
-                TotalMilliSeconds = (int)vr.TotalTime.TotalSeconds;
+                TotalMilliSeconds = (int)vr.TotalTime.TotalMilliseconds;
                 return;
             }
 
             using var afr = new AudioFileReader(FullName);
-            var time = (int)afr.TotalTime.TotalSeconds;
+            var time = (int)afr.TotalTime.TotalMilliseconds;
             TotalMilliSeconds = time;
         }
     }

--- a/MusicerBeat/Models/SoundFile.cs
+++ b/MusicerBeat/Models/SoundFile.cs
@@ -13,7 +13,7 @@ namespace MusicerBeat.Models
     {
         private string fullName;
         private string name;
-        private int totalSeconds;
+        private int totalMilliSeconds;
         private int listenCount;
         private bool isSkip;
         private bool playing;
@@ -56,7 +56,7 @@ namespace MusicerBeat.Models
         [NotMapped]
         public string Extension { get; set; }
 
-        public int TotalSeconds { get => totalSeconds; set => SetProperty(ref totalSeconds, value); }
+        public int TotalMilliSeconds { get => totalMilliSeconds; set => SetProperty(ref totalMilliSeconds, value); }
 
         public int ListenCount { get => listenCount; set => SetProperty(ref listenCount, value); }
 
@@ -79,13 +79,13 @@ namespace MusicerBeat.Models
             if (Extension == ".ogg")
             {
                 using var vr = new VorbisReader(FullName);
-                TotalSeconds = (int)vr.TotalTime.TotalSeconds;
+                TotalMilliSeconds = (int)vr.TotalTime.TotalSeconds;
                 return;
             }
 
             using var afr = new AudioFileReader(FullName);
             var time = (int)afr.TotalTime.TotalSeconds;
-            TotalSeconds = time;
+            TotalMilliSeconds = time;
         }
     }
 }

--- a/MusicerBeat/Models/TextWrapper.cs
+++ b/MusicerBeat/Models/TextWrapper.cs
@@ -30,9 +30,9 @@ namespace MusicerBeat.Models
         private void SetVersion()
         {
             const int major = 0;
-            const int minor = 15;
+            const int minor = 16;
             const int patch = 0;
-            const string date = "20250304";
+            const string date = "20250306";
             const string suffixId = "a";
 
             Version = $"{major}.{minor}.{patch} ({date}{suffixId})";

--- a/MusicerBeat/ViewModels/PlaybackControlViewmodel.cs
+++ b/MusicerBeat/ViewModels/PlaybackControlViewmodel.cs
@@ -22,6 +22,7 @@ namespace MusicerBeat.ViewModels
         private readonly DispatcherTimer timer;
         private TimeSpan crossFadeDuration = TimeSpan.FromSeconds(10);
         private float volume = 1.0f;
+        private PlayingStatus playingStatus;
 
         public PlaybackControlViewmodel(IPlaylist playlist, ISoundPlayerFactory soundPlayerFactory)
         {
@@ -77,6 +78,12 @@ namespace MusicerBeat.ViewModels
             }
         }
 
+        public PlayingStatus PlayingStatus
+        {
+            get => playingStatus;
+            set => SetProperty(ref playingStatus, value);
+        }
+
         private IPlaylist PlayListSource { get; init; }
 
         public PlayingStatus GetStatus()
@@ -118,10 +125,18 @@ namespace MusicerBeat.ViewModels
                 }
             }
 
-            if (GetStatus() == PlayingStatus.Fading)
+            var state = GetStatus();
+
+            if (state == PlayingStatus.Fading)
             {
                 VolumeController.ChangeVolumes();
+                PlayingStatus = PlayingStatus.Fading;
+                return;
             }
+
+            PlayingStatus = state == PlayingStatus.Playing
+                ? PlayingStatus.Playing
+                : PlayingStatus.Stopped;
         }
 
         protected virtual void Dispose(bool disposing)

--- a/MusicerBeat/ViewModels/PlaybackControlViewmodel.cs
+++ b/MusicerBeat/ViewModels/PlaybackControlViewmodel.cs
@@ -21,7 +21,6 @@ namespace MusicerBeat.ViewModels
 
         private readonly DispatcherTimer timer;
         private TimeSpan crossFadeDuration = TimeSpan.FromSeconds(10);
-        private string soundFileName = string.Empty;
 
         public PlaybackControlViewmodel(IPlaylist playlist, ISoundPlayerFactory soundPlayerFactory)
         {

--- a/MusicerBeat/ViewModels/PlaybackControlViewmodel.cs
+++ b/MusicerBeat/ViewModels/PlaybackControlViewmodel.cs
@@ -18,6 +18,7 @@ namespace MusicerBeat.ViewModels
         private readonly ISoundPlayerFactory soundPlayerFactory;
         private readonly List<ISoundPlayer> soundPlayers = new ();
         private readonly SoundFileService soundFileService;
+        private readonly SoundPlayerMixer soundPlayerMixer;
 
         private readonly DispatcherTimer timer;
         private TimeSpan crossFadeDuration = TimeSpan.FromSeconds(10);
@@ -30,6 +31,9 @@ namespace MusicerBeat.ViewModels
             timer.Tick += Timer_Tick;
             VolumeController = new VolumeController(soundPlayers);
             CrossFadeDuration = TimeSpan.FromSeconds(10);
+
+            soundPlayerMixer = new SoundPlayerMixer(soundPlayers, soundPlayerFactory);
+
             timer.Start();
         }
 
@@ -66,31 +70,7 @@ namespace MusicerBeat.ViewModels
 
         public PlayingStatus GetStatus()
         {
-            if (soundPlayers.Count == 0)
-            {
-                return PlayingStatus.Stopped;
-            }
-
-            if (soundPlayers.Count == 1)
-            {
-                if (!soundPlayers.First().IsPlaying)
-                {
-                    throw new InvalidOperationException("Invalid Status");
-                }
-
-                return PlayingStatus.Playing;
-            }
-
-            if (soundPlayers.Count == 2)
-            {
-                if (soundPlayers.All(p => p.IsPlaying))
-                {
-                    // リストの中のプレイヤーが両方動いている。
-                    return PlayingStatus.Fading;
-                }
-            }
-
-            throw new InvalidOperationException("Invalid Status");
+            return soundPlayerMixer.GetStatus();
         }
 
         public void Dispose()

--- a/MusicerBeat/ViewModels/PlaybackControlViewmodel.cs
+++ b/MusicerBeat/ViewModels/PlaybackControlViewmodel.cs
@@ -21,6 +21,7 @@ namespace MusicerBeat.ViewModels
 
         private readonly DispatcherTimer timer;
         private TimeSpan crossFadeDuration = TimeSpan.FromSeconds(10);
+        private float volume = 1.0f;
 
         public PlaybackControlViewmodel(IPlaylist playlist, ISoundPlayerFactory soundPlayerFactory)
         {
@@ -45,6 +46,17 @@ namespace MusicerBeat.ViewModels
         public bool IsPlaying { get; set; }
 
         public VolumeController VolumeController { get; set; }
+
+        public float Volume
+        {
+            get => volume;
+            set
+            {
+                SetProperty(ref volume, value);
+                VolumeController.CurrentVolume = value;
+                soundPlayerMixer.DefaultVolume = value;
+            }
+        }
 
         public PlaybackInformationViewer PlaybackInformationViewer { get; set; } = new ();
 

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -157,8 +157,14 @@
                 <RowDefinition />
             </Grid.RowDefinitions>
 
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition />
+                <ColumnDefinition />
+            </Grid.ColumnDefinitions>
+
             <Button
                 Grid.Row="0"
+                Grid.Column="0"
                 Width="100"
                 Margin="15"
                 HorizontalAlignment="Left"
@@ -166,8 +172,26 @@
                 Command="{Binding PlaybackControlViewmodel.PlayCommand}"
                 Content="▷" />
 
+            <StackPanel
+                Grid.Row="0"
+                Grid.Column="1"
+                Margin="15"
+                HorizontalAlignment="Right"
+                Orientation="Horizontal">
+                <TextBlock Text="Vol :" />
+                <Border Margin="5,0" />
+                <Slider
+                    Width="250"
+                    HorizontalAlignment="Right"
+                    Maximum="1.0"
+                    Minimum="0"
+                    Value="{Binding PlaybackControlViewmodel.Volume}" />
+            </StackPanel>
+
             <Border
                 Grid.Row="1"
+                Grid.Column="0"
+                Grid.ColumnSpan="2"
                 HorizontalAlignment="Stretch"
                 Background="LightSteelBlue">
                 <StackPanel Margin="4" Orientation="Horizontal">

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -185,7 +185,17 @@
                     HorizontalAlignment="Right"
                     Maximum="1.0"
                     Minimum="0"
-                    Value="{Binding PlaybackControlViewmodel.Volume}" />
+                    Value="{Binding PlaybackControlViewmodel.Volume}">
+                    <Slider.Style>
+                        <Style TargetType="Slider">
+                            <Style.Triggers>
+                                <DataTrigger Binding="{Binding PlaybackControlViewmodel.PlayingStatus}" Value="{x:Static models:PlayingStatus.Fading}">
+                                    <Setter Property="IsEnabled" Value="False" />
+                                </DataTrigger>
+                            </Style.Triggers>
+                        </Style>
+                    </Slider.Style>
+                </Slider>
             </StackPanel>
 
             <Border

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -132,7 +132,7 @@
                         <TextBlock
                             Grid.Column="3"
                             Margin="5,0"
-                            Text="{Binding TotalSeconds, Converter={StaticResource IntToTimeSpanConverter}}" />
+                            Text="{Binding TotalMilliSeconds, Converter={StaticResource IntToTimeSpanConverter}}" />
 
                     </Grid>
                 </DataTemplate>

--- a/MusicerBeatTests/Models/SequentialSelectorTest.cs
+++ b/MusicerBeatTests/Models/SequentialSelectorTest.cs
@@ -201,9 +201,9 @@ namespace MusicerBeatTests.Models
         {
             var list = new ObservableCollection<SoundFile>()
             {
-                new SoundFile("C://t/file1.mp3") { TotalMilliSeconds = 20, },
-                new SoundFile("C://t/file2.mp3") { TotalMilliSeconds = 10, },
-                new SoundFile("C://t/file3.mp3") { TotalMilliSeconds = 5, },
+                new SoundFile("C://t/file1.mp3") { TotalMilliSeconds = 20000, },
+                new SoundFile("C://t/file2.mp3") { TotalMilliSeconds = 10000, },
+                new SoundFile("C://t/file3.mp3") { TotalMilliSeconds = 5000, },
             };
 
             var s = new SequentialSelector(new ReadOnlyObservableCollection<SoundFile>(list))

--- a/MusicerBeatTests/Models/SequentialSelectorTest.cs
+++ b/MusicerBeatTests/Models/SequentialSelectorTest.cs
@@ -201,9 +201,9 @@ namespace MusicerBeatTests.Models
         {
             var list = new ObservableCollection<SoundFile>()
             {
-                new SoundFile("C://t/file1.mp3") { TotalSeconds = 20, },
-                new SoundFile("C://t/file2.mp3") { TotalSeconds = 10, },
-                new SoundFile("C://t/file3.mp3") { TotalSeconds = 5, },
+                new SoundFile("C://t/file1.mp3") { TotalMilliSeconds = 20, },
+                new SoundFile("C://t/file2.mp3") { TotalMilliSeconds = 10, },
+                new SoundFile("C://t/file3.mp3") { TotalMilliSeconds = 5, },
             };
 
             var s = new SequentialSelector(new ReadOnlyObservableCollection<SoundFile>(list))

--- a/MusicerBeatTests/Models/Service/SoundPlayerMixerTest.cs
+++ b/MusicerBeatTests/Models/Service/SoundPlayerMixerTest.cs
@@ -1,0 +1,7 @@
+namespace MusicerBeatTests.Models.Service
+{
+    [TestFixture]
+    public class SoundPlayerMixerTest
+    {
+    }
+}

--- a/MusicerBeatTests/Models/Service/SoundPlayerMixerTest.cs
+++ b/MusicerBeatTests/Models/Service/SoundPlayerMixerTest.cs
@@ -1,7 +1,43 @@
+using MusicerBeat.Models;
+using MusicerBeat.Models.Interfaces;
+using MusicerBeat.Models.Services;
+using MusicerBeatTests.ViewModels;
+
 namespace MusicerBeatTests.Models.Service
 {
     [TestFixture]
     public class SoundPlayerMixerTest
     {
+        private static IEnumerable<TestCaseData> GetStatusTestCases()
+        {
+            yield return new TestCaseData(
+                new List<ISoundPlayer>(),
+                PlayingStatus.Stopped
+            ).SetName("停止中");
+
+            yield return new TestCaseData(
+                new List<ISoundPlayer>
+                {
+                    new MockSoundPlayer(TimeSpan.Zero, true),
+                },
+                PlayingStatus.Playing
+            ).SetName("通常の再生中");
+
+            yield return new TestCaseData(
+                new List<ISoundPlayer>
+                {
+                    new MockSoundPlayer(TimeSpan.Zero, true),
+                    new MockSoundPlayer(TimeSpan.Zero, true),
+                },
+                PlayingStatus.Fading
+            ).SetName("曲のフェード中");
+        }
+
+        [TestCaseSource(nameof(GetStatusTestCases))]
+        public void GetStatusTest(List<ISoundPlayer> players, PlayingStatus expectedStatus)
+        {
+            var mixer = new SoundPlayerMixer(players, new DummySoundPlayerFactory());
+            Assert.That(mixer.GetStatus(), Is.EqualTo(expectedStatus));
+        }
     }
 }

--- a/MusicerBeatTests/Models/VolumeControllerTest.cs
+++ b/MusicerBeatTests/Models/VolumeControllerTest.cs
@@ -1,4 +1,3 @@
-using MusicerBeat.Models;
 using MusicerBeat.Models.Services;
 using MusicerBeatTests.ViewModels;
 

--- a/MusicerBeatTests/ViewModels/DummySoundPlayerFactory.cs
+++ b/MusicerBeatTests/ViewModels/DummySoundPlayerFactory.cs
@@ -1,4 +1,3 @@
-using MusicerBeat.Models;
 using MusicerBeat.Models.Interfaces;
 
 namespace MusicerBeatTests.ViewModels

--- a/MusicerBeatTests/ViewModels/MockSoundPlayer.cs
+++ b/MusicerBeatTests/ViewModels/MockSoundPlayer.cs
@@ -54,9 +54,9 @@ namespace MusicerBeatTests.ViewModels
 
         public void PlaySound(SoundFile soundFile)
         {
-            if (soundFile.TotalSeconds > 0)
+            if (soundFile.TotalMilliSeconds > 0)
             {
-                Duration = TimeSpan.FromSeconds(soundFile.TotalSeconds);
+                Duration = TimeSpan.FromSeconds(soundFile.TotalMilliSeconds);
             }
 
             LastPlayedSoundFile = soundFile;

--- a/MusicerBeatTests/ViewModels/MockSoundPlayer.cs
+++ b/MusicerBeatTests/ViewModels/MockSoundPlayer.cs
@@ -11,11 +11,12 @@ namespace MusicerBeatTests.ViewModels
         {
         }
 
-        public MockSoundPlayer(TimeSpan defaultCurrentTime)
+        public MockSoundPlayer(TimeSpan defaultCurrentTime, bool defaultPlaying = false)
         {
             IsPlaying = true;
             CurrentTime = defaultCurrentTime;
             IsPlaying = false;
+            IsPlaying = defaultPlaying;
         }
 
         public event EventHandler? SoundEnded;

--- a/MusicerBeatTests/ViewModels/MockSoundPlayer.cs
+++ b/MusicerBeatTests/ViewModels/MockSoundPlayer.cs
@@ -56,7 +56,7 @@ namespace MusicerBeatTests.ViewModels
         {
             if (soundFile.TotalMilliSeconds > 0)
             {
-                Duration = TimeSpan.FromSeconds(soundFile.TotalMilliSeconds);
+                Duration = TimeSpan.FromMilliseconds(soundFile.TotalMilliSeconds);
             }
 
             LastPlayedSoundFile = soundFile;

--- a/MusicerBeatTests/ViewModels/PlaybackControlViewModelTest.cs
+++ b/MusicerBeatTests/ViewModels/PlaybackControlViewModelTest.cs
@@ -42,10 +42,10 @@ namespace MusicerBeatTests.ViewModels
         public void PlayCommand_StateTransitionTest()
         {
             var playList = new MockPlaylist();
-            playList.OriginalList.Add(new SoundFile("C://test/a.mp3") { TotalMilliSeconds = 2, });
-            playList.OriginalList.Add(new SoundFile("C://test/b.mp3") { TotalMilliSeconds = 2, });
-            playList.OriginalList.Add(new SoundFile("C://test/c.mp3") { TotalMilliSeconds = 1, });
-            playList.OriginalList.Add(new SoundFile("C://test/d.mp3") { TotalMilliSeconds = 2, });
+            playList.OriginalList.Add(new SoundFile("C://test/a.mp3") { TotalMilliSeconds = 2000, });
+            playList.OriginalList.Add(new SoundFile("C://test/b.mp3") { TotalMilliSeconds = 2000, });
+            playList.OriginalList.Add(new SoundFile("C://test/c.mp3") { TotalMilliSeconds = 1000, });
+            playList.OriginalList.Add(new SoundFile("C://test/d.mp3") { TotalMilliSeconds = 2000, });
 
             var ps = new List<MockSoundPlayer>
             {
@@ -92,10 +92,10 @@ namespace MusicerBeatTests.ViewModels
             yield return (
                 new List<(string, int, string)>
                 {
-                    (@"C:\test\a.mp3", 2, "p1"),
-                    (@"C:\test\b.mp3", 2, "p2"),
-                    (@"C:\test\c.mp3", 2, "p3"),
-                    (@"C:\test\d.mp3", 2, "p4"),
+                    (@"C:\test\a.mp3", 2000, "p1"),
+                    (@"C:\test\b.mp3", 2000, "p2"),
+                    (@"C:\test\c.mp3", 2000, "p3"),
+                    (@"C:\test\d.mp3", 2000, "p4"),
                 },
                 new List<(TimeSpan, double?, double?, string)>
                 {
@@ -123,10 +123,10 @@ namespace MusicerBeatTests.ViewModels
             yield return (
                 new List<(string, int, string)>
                 {
-                    (@"C:\test\a.mp3", 2, "p1"),
-                    (@"C:\test\b.mp3", 2, "p2"),
-                    (@"C:\test\c.mp3", 1, "p3"),
-                    (@"C:\test\d.mp3", 2, "p4"),
+                    (@"C:\test\a.mp3", 2000, "p1"),
+                    (@"C:\test\b.mp3", 2000, "p2"),
+                    (@"C:\test\c.mp3", 1000, "p3"),
+                    (@"C:\test\d.mp3", 2000, "p4"),
                 },
                 new List<(TimeSpan, double?, double?, string)>
                 {
@@ -148,9 +148,9 @@ namespace MusicerBeatTests.ViewModels
             yield return (
                 new List<(string, int, string)>
                 {
-                    (@"C:\test\a.mp3", 1, "p1"),
-                    (@"C:\test\b.mp3", 1, "p2"),
-                    (@"C:\test\c.mp3", 1, "p3"),
+                    (@"C:\test\a.mp3", 1000, "p1"),
+                    (@"C:\test\b.mp3", 1000, "p2"),
+                    (@"C:\test\c.mp3", 1000, "p3"),
                 },
                 new List<(TimeSpan, double?, double?, string)>
                 {

--- a/MusicerBeatTests/ViewModels/PlaybackControlViewModelTest.cs
+++ b/MusicerBeatTests/ViewModels/PlaybackControlViewModelTest.cs
@@ -42,10 +42,10 @@ namespace MusicerBeatTests.ViewModels
         public void PlayCommand_StateTransitionTest()
         {
             var playList = new MockPlaylist();
-            playList.OriginalList.Add(new SoundFile("C://test/a.mp3") { TotalSeconds = 2, });
-            playList.OriginalList.Add(new SoundFile("C://test/b.mp3") { TotalSeconds = 2, });
-            playList.OriginalList.Add(new SoundFile("C://test/c.mp3") { TotalSeconds = 1, });
-            playList.OriginalList.Add(new SoundFile("C://test/d.mp3") { TotalSeconds = 2, });
+            playList.OriginalList.Add(new SoundFile("C://test/a.mp3") { TotalMilliSeconds = 2, });
+            playList.OriginalList.Add(new SoundFile("C://test/b.mp3") { TotalMilliSeconds = 2, });
+            playList.OriginalList.Add(new SoundFile("C://test/c.mp3") { TotalMilliSeconds = 1, });
+            playList.OriginalList.Add(new SoundFile("C://test/d.mp3") { TotalMilliSeconds = 2, });
 
             var ps = new List<MockSoundPlayer>
             {
@@ -174,7 +174,7 @@ namespace MusicerBeatTests.ViewModels
             var playList = new MockPlaylist();
             foreach (var data in args.soundAndPlayers)
             {
-                playList.OriginalList.Add(new SoundFile(data.soundFilePath) { TotalSeconds = data.duration, });
+                playList.OriginalList.Add(new SoundFile(data.soundFilePath) { TotalMilliSeconds = data.duration, });
             }
 
             var ps =


### PR DESCRIPTION
 - データベーススキーマの変更
     - `SoundFile.TotalSeconds`  を `SoundFile.TotalMilliSeconds` に変更した。

 この変更により、前バージョンまでとはデータベースの互換性がありません。
 開発途中のバージョンであるため、マイグレーションは実施しません。
 DBファイルを削除して対応します。

 - 機能追加
     - サウンドの再生開始時の音量を調節するスライダーを設置した。
 - リファクタリング 
     - `SoundPlayerMixer`  を実装し、`PlaybackControlViewmodel` の機能を一部委譲した。