### PR TITLE
リリース / v1.1.2

### DIFF
--- a/MusicerBeat/Models/PlaybackInformationViewer.cs
+++ b/MusicerBeat/Models/PlaybackInformationViewer.cs
@@ -10,6 +10,8 @@ namespace MusicerBeat.Models
         private readonly string shortTimeFormat = @"hh\:mm\:ss";
         private string playingFileName = string.Empty;
         private string playbackTimeString = string.Empty;
+        private int currentSoundLength;
+        private int currentSoundPosition;
 
         public string PlayingFileName
         {
@@ -23,6 +25,24 @@ namespace MusicerBeat.Models
             set => SetProperty(ref playbackTimeString, value);
         }
 
+        /// <summary>
+        /// 現在再生中のサウンドの長さを秒数で取得します。
+        /// </summary>
+        public int CurrentSoundLength
+        {
+            get => currentSoundLength;
+            private set => SetProperty(ref currentSoundLength, value);
+        }
+
+        /// <summary>
+        /// 現在再生中のサウンドの再生位置を秒数で取得します。
+        /// </summary>
+        public int CurrentSoundPosition
+        {
+            get => currentSoundPosition;
+            set => SetProperty(ref currentSoundPosition, value);
+        }
+
         public void UpdatePlaybackInformation(IEnumerable<ISoundPlayer> players)
         {
             var list = players.ToList();
@@ -30,7 +50,17 @@ namespace MusicerBeat.Models
             {
                 PlayingFileName = string.Empty;
                 PlaybackTimeString = string.Empty;
+                CurrentSoundLength = 0;
+                CurrentSoundPosition = 0;
                 return;
+            }
+
+            if (list.Count >= 1)
+            {
+                CurrentSoundLength = (int)list.First().Duration.TotalSeconds;
+                CurrentSoundPosition = (int)list.First().CurrentTime.TotalSeconds;
+                System.Diagnostics.Debug.WriteLine($"{CurrentSoundLength}(PlaybackInformationViewer : 57)");
+                System.Diagnostics.Debug.WriteLine($"{CurrentSoundPosition}(PlaybackInformationViewer : 58)");
             }
 
             if (list.Count == 1)

--- a/MusicerBeat/Models/TextWrapper.cs
+++ b/MusicerBeat/Models/TextWrapper.cs
@@ -31,8 +31,8 @@ namespace MusicerBeat.Models
         {
             const int major = 1;
             const int minor = 1;
-            const int patch = 1;
-            const string date = "20250406";
+            const int patch = 2;
+            const string date = "20250407";
             const string suffixId = "a";
 
             Version = $"{major}.{minor}.{patch} ({date}{suffixId})";

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -302,17 +302,25 @@
                 Grid.ColumnSpan="2"
                 HorizontalAlignment="Stretch"
                 Background="LightSteelBlue">
-                <StackPanel Margin="4" Orientation="Horizontal">
+                <StackPanel>
+                    <StackPanel Margin="4" Orientation="Horizontal">
 
-                    <StackPanel.Resources>
-                        <Style TargetType="TextBlock">
-                            <Setter Property="Foreground" Value="Black" />
-                            <Setter Property="FontSize" Value="{StaticResource BasicFontSize}" />
-                        </Style>
-                    </StackPanel.Resources>
+                        <StackPanel.Resources>
+                            <Style TargetType="TextBlock">
+                                <Setter Property="Foreground" Value="Black" />
+                                <Setter Property="FontSize" Value="{StaticResource BasicFontSize}" />
+                            </Style>
+                        </StackPanel.Resources>
 
-                    <TextBlock Text="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.PlayingFileName}" />
-                    <TextBlock Margin="4,0" Text="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.PlaybackTimeString}" />
+                        <TextBlock Text="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.PlayingFileName}" />
+                        <TextBlock Margin="4,0" Text="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.PlaybackTimeString}" />
+                    </StackPanel>
+
+                    <ProgressBar
+                        Height="3"
+                        Maximum="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.CurrentSoundLength}"
+                        Minimum="0"
+                        Value="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.CurrentSoundPosition}" />
                 </StackPanel>
             </Border>
         </Grid>

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -46,7 +46,7 @@
         </Grid.RowDefinitions>
 
         <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="0.4*" />
+            <ColumnDefinition Width="0.6*" />
             <ColumnDefinition Width="Auto" />
             <ColumnDefinition Width="1*" />
         </Grid.ColumnDefinitions>


### PR DESCRIPTION
- 外観
    - サウンドの再生位置を表示するプログレスバーをウィンドウ下部に設置。
    - ツリービューの画面に占める割合（サイズ）を広めに変更。