### PR TITLE
リリース / v1.3.2

### DIFF
--- a/MusicerBeat/Converters/VolumePercentageConverter.cs
+++ b/MusicerBeat/Converters/VolumePercentageConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace MusicerBeat.Converters
+{
+    public class VolumePercentageConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            if (value == null)
+            {
+                return 0;
+            }
+
+            var param = (int)((float)value * 100);
+            return param;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return Binding.DoNothing;
+        }
+    }
+}

--- a/MusicerBeat/Models/TextWrapper.cs
+++ b/MusicerBeat/Models/TextWrapper.cs
@@ -31,8 +31,8 @@ namespace MusicerBeat.Models
         {
             const int major = 1;
             const int minor = 3;
-            const int patch = 1;
-            const string date = "20250413";
+            const int patch = 2;
+            const string date = "d20250414";
             const string suffixId = "a";
 
             Version = $"{major}.{minor}.{patch} ({date}{suffixId})";

--- a/MusicerBeat/ViewModels/PlaybackControlViewmodel.cs
+++ b/MusicerBeat/ViewModels/PlaybackControlViewmodel.cs
@@ -163,6 +163,7 @@ namespace MusicerBeat.ViewModels
             soundFile ??= PlayListSource.SequentialSelector.SelectSoundFile();
             if (soundFile == null)
             {
+                PlayListSource.SequentialSelector.ResetIndex();
                 return;
             }
 

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -2,6 +2,7 @@
     x:Class="MusicerBeat.Views.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="clr-namespace:MusicerBeat.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:i="http://schemas.microsoft.com/xaml/behaviors"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -21,6 +22,8 @@
             <ResourceDictionary.MergedDictionaries>
                 <ResourceDictionary Source="Themes/CustomTVControlTemplate.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+            <converters:VolumePercentageConverter x:Key="VolumePercentageConverter" />
         </ResourceDictionary>
     </Window.Resources>
 
@@ -311,6 +314,10 @@
                 </ToggleButton>
 
                 <TextBlock Text="Vol :" />
+                <TextBlock
+                    Width="25"
+                    Text="{Binding PlaybackControlViewmodel.Volume, Converter={StaticResource VolumePercentageConverter}}"
+                    TextAlignment="Center" />
                 <Border Margin="5,0" />
                 <Slider
                     Width="250"

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -317,6 +317,7 @@
                     HorizontalAlignment="Right"
                     Maximum="1.0"
                     Minimum="0"
+                    Ticks="0.01"
                     Value="{Binding PlaybackControlViewmodel.Volume}">
                     <Slider.Style>
                         <Style TargetType="Slider">

--- a/MusicerBeatTests/ViewModels/PlaybackControlViewModelTest.cs
+++ b/MusicerBeatTests/ViewModels/PlaybackControlViewModelTest.cs
@@ -458,6 +458,23 @@ namespace MusicerBeatTests.ViewModels
             }
         }
 
+        [Test]
+        public void ResetIndexToZero_WhenCompletePlaySounds()
+        {
+            var vmParams = CreatePlaybackControlVmParams();
+            var vm = new PlaybackControlViewmodel(vmParams.PlayListSource, vmParams.SpFactory);
+
+            var indexTransitions = new List<int>();
+
+            for (int i = 0; i < 3; i++)
+            {
+                vm.PlayCommand.Execute(null);
+                indexTransitions.Add(vmParams.PlayListSource.SequentialSelector.Index);
+            }
+
+            CollectionAssert.AreEqual(new int[] { 1, 2, 0, }, indexTransitions);
+        }
+
         private (MockPlaylist PlayListSource, DummySoundPlayerFactory SpFactory) CreatePlaybackControlVmParams()
         {
             var soundFiles = new List<SoundFile>


### PR DESCRIPTION
- 機能改善
    - ボリュームスライダーの値の変化を 0.01 刻みに設定。
    - ボリュームの値を 1-100 の間の値で表示。
- 修正
    - プレイリスト再生完了後、インデックスがリセットされない不具合を修正。
