### PR TITLE
リリース / v1.4.1

### DIFF
--- a/MusicerBeat/Models/Databases/SoundFileService.cs
+++ b/MusicerBeat/Models/Databases/SoundFileService.cs
@@ -112,6 +112,7 @@ namespace MusicerBeat.Models.Databases
                 var file = await soundFileRepository.GetByIdAsync(lh.SoundFileId);
                 var soundFile = new SoundFile(file.FullName);
                 lh.SoundFileName = soundFile.Name;
+                lh.DirectoryName = soundFile.DirectoryName;
             }
 
             return paged;

--- a/MusicerBeat/Models/ListenHistory.cs
+++ b/MusicerBeat/Models/ListenHistory.cs
@@ -14,5 +14,8 @@ namespace MusicerBeat.Models
 
         [NotMapped]
         public string SoundFileName { get; set; } = string.Empty;
+
+        [NotMapped]
+        public string DirectoryName { get; set; } = string.Empty;
     }
 }

--- a/MusicerBeat/Models/SoundFile.cs
+++ b/MusicerBeat/Models/SoundFile.cs
@@ -19,6 +19,7 @@ namespace MusicerBeat.Models
         private bool playing;
         private string nameWithoutExtension;
         private int index;
+        private string directoryName = string.Empty;
 
         public SoundFile(string filePath)
         {
@@ -31,6 +32,7 @@ namespace MusicerBeat.Models
             Name = Path.GetFileName(filePath);
             NameWithoutExtension = Path.GetFileNameWithoutExtension(filePath);
             Extension = Path.GetExtension(filePath).ToLower();
+            DirectoryName = Path.GetDirectoryName(filePath);
         }
 
         // ReSharper disable once UnusedMember.Global
@@ -52,6 +54,9 @@ namespace MusicerBeat.Models
             get => nameWithoutExtension;
             set => SetProperty(ref nameWithoutExtension, value);
         }
+
+        [NotMapped]
+        public string DirectoryName { get => directoryName; set => SetProperty(ref directoryName, value); }
 
         [NotMapped]
         public string Extension { get; set; }

--- a/MusicerBeat/Models/TextWrapper.cs
+++ b/MusicerBeat/Models/TextWrapper.cs
@@ -31,8 +31,8 @@ namespace MusicerBeat.Models
         {
             const int major = 1;
             const int minor = 4;
-            const int patch = 0;
-            const string date = "20250424";
+            const int patch = 1;
+            const string date = "20250425";
             const string suffixId = "a";
 
             Version = $"{major}.{minor}.{patch} ({date}{suffixId})";

--- a/MusicerBeat/Views/HistoryPage.xaml
+++ b/MusicerBeat/Views/HistoryPage.xaml
@@ -37,15 +37,23 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition />
                             <ColumnDefinition />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
-                        <TextBlock Grid.Column="0" Text="{Binding SoundFileName}" />
-                        <TextBlock Grid.Column="1" Text="{Binding DateTime, StringFormat={}{0:yyyy/MM/dd HH:mm}}" />
+                        <TextBlock Grid.Column="0" Text="{Binding DirectoryName}" />
+                        <TextBlock
+                            Grid.Column="1"
+                            Margin="10,0"
+                            HorizontalAlignment="Left"
+                            Text="{Binding SoundFileName}" />
+                        <TextBlock Grid.Column="2" Text="{Binding DateTime, StringFormat={}{0:yyyy/MM/dd HH:mm}}" />
                     </Grid>
                 </DataTemplate>
             </ListBox.ItemTemplate>
+
             <ListBox.ItemContainerStyle>
                 <Style TargetType="ListBoxItem">
+                    <Setter Property="Margin" Value="0,1" />
                     <Style.Triggers>
                         <Trigger Property="ItemsControl.AlternationIndex" Value="1">
                             <Setter Property="Background" Value="{StaticResource MediumBgBrush}" />

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -359,8 +359,14 @@
                     Grid.Row="1"
                     Grid.Column="0"
                     Grid.ColumnSpan="2"
-                    HorizontalAlignment="Stretch"
-                    Background="LightSteelBlue">
+                    HorizontalAlignment="Stretch">
+                    <Border.Background>
+                        <LinearGradientBrush StartPoint="0,0" EndPoint="1,1">
+                            <GradientStop Offset="0.1" Color="LightSteelBlue" />
+                            <GradientStop Offset="1.0" Color="LightSkyBlue" />
+                        </LinearGradientBrush>
+                    </Border.Background>
+
                     <StackPanel>
                         <StackPanel Margin="4" Orientation="Horizontal">
 

--- a/MusicerBeat/Views/MainWindow.xaml
+++ b/MusicerBeat/Views/MainWindow.xaml
@@ -261,124 +261,129 @@
             </ListBox.ItemContainerStyle>
         </ListBox>
 
-        <Grid
+        <Border
             Grid.Row="2"
             Grid.Column="0"
-            Grid.ColumnSpan="3">
-            <Grid.RowDefinitions>
-                <RowDefinition />
-                <RowDefinition />
-            </Grid.RowDefinitions>
+            Grid.ColumnSpan="3"
+            BorderBrush="Gray"
+            BorderThickness="0,1,0,0">
 
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition />
-                <ColumnDefinition />
-            </Grid.ColumnDefinitions>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition />
+                    <RowDefinition />
+                </Grid.RowDefinitions>
 
-            <StackPanel
-                Grid.Row="0"
-                Grid.Column="0"
-                Orientation="Horizontal">
-                <Button
-                    Width="100"
-                    Margin="10"
-                    Padding="2"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Center"
-                    Command="{Binding PlaybackControlViewmodel.PlayCommand}">
-                    <iconPacks:PackIconMaterial Height="18" Kind="Play" />
-                </Button>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
 
-                <Button
-                    Width="80"
-                    Margin="10"
-                    Padding="2"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Center"
-                    Command="{Binding PlaybackControlViewmodel.PlayNextCommand}">
-                    <iconPacks:PackIconMaterial Height="18" Kind="SkipNext" />
-                </Button>
+                <StackPanel
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    Orientation="Horizontal">
+                    <Button
+                        Width="100"
+                        Margin="10"
+                        Padding="2"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center"
+                        Command="{Binding PlaybackControlViewmodel.PlayCommand}">
+                        <iconPacks:PackIconMaterial Height="18" Kind="Play" />
+                    </Button>
 
-                <Button
-                    Width="60"
-                    Padding="2"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Center"
-                    Command="{Binding PlaybackControlViewmodel.StopCommand}">
-                    <iconPacks:PackIconMaterial Height="18" Kind="Stop" />
-                </Button>
-            </StackPanel>
+                    <Button
+                        Width="80"
+                        Margin="10"
+                        Padding="2"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center"
+                        Command="{Binding PlaybackControlViewmodel.PlayNextCommand}">
+                        <iconPacks:PackIconMaterial Height="18" Kind="SkipNext" />
+                    </Button>
 
-            <StackPanel
-                Grid.Row="0"
-                Grid.Column="1"
-                Margin="15"
-                HorizontalAlignment="Right"
-                Orientation="Horizontal">
-                <ToggleButton Margin="15,0" IsChecked="{Binding PlaybackControlViewmodel.PlayListSource.SequentialSelector.IsLoop}">
-                    <ToggleButton.Content>
-                        <TextBlock
-                            Margin="8,0"
-                            Foreground="Black"
-                            Text="Loop" />
-                    </ToggleButton.Content>
-                </ToggleButton>
-
-                <TextBlock VerticalAlignment="Center" Text="Vol :" />
-                <TextBlock
-                    Width="25"
-                    VerticalAlignment="Center"
-                    Text="{Binding PlaybackControlViewmodel.Volume, Converter={StaticResource VolumePercentageConverter}}"
-                    TextAlignment="Center" />
-                <Border Margin="5,0" />
-                <Slider
-                    Width="250"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Center"
-                    Maximum="1.0"
-                    Minimum="0"
-                    Ticks="0.01"
-                    Value="{Binding PlaybackControlViewmodel.Volume}">
-                    <Slider.Style>
-                        <Style TargetType="Slider">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding PlaybackControlViewmodel.PlayingStatus}" Value="{x:Static models:PlayingStatus.Fading}">
-                                    <Setter Property="IsEnabled" Value="False" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
-                    </Slider.Style>
-                </Slider>
-            </StackPanel>
-
-            <Border
-                Grid.Row="1"
-                Grid.Column="0"
-                Grid.ColumnSpan="2"
-                HorizontalAlignment="Stretch"
-                Background="LightSteelBlue">
-                <StackPanel>
-                    <StackPanel Margin="4" Orientation="Horizontal">
-
-                        <StackPanel.Resources>
-                            <Style TargetType="TextBlock">
-                                <Setter Property="Foreground" Value="Black" />
-                                <Setter Property="FontSize" Value="{StaticResource BasicFontSize}" />
-                            </Style>
-                        </StackPanel.Resources>
-
-                        <TextBlock Text="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.PlayingFileName}" />
-                        <TextBlock Margin="4,0" Text="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.PlaybackTimeString}" />
-                    </StackPanel>
-
-                    <controls:MetroProgressBar
-                        Height="3"
-                        Maximum="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.CurrentSoundLength}"
-                        Minimum="0"
-                        Value="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.CurrentSoundPosition}" />
+                    <Button
+                        Width="60"
+                        Padding="2"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center"
+                        Command="{Binding PlaybackControlViewmodel.StopCommand}">
+                        <iconPacks:PackIconMaterial Height="18" Kind="Stop" />
+                    </Button>
                 </StackPanel>
-            </Border>
-        </Grid>
+
+                <StackPanel
+                    Grid.Row="0"
+                    Grid.Column="1"
+                    Margin="15"
+                    HorizontalAlignment="Right"
+                    Orientation="Horizontal">
+                    <ToggleButton Margin="15,0" IsChecked="{Binding PlaybackControlViewmodel.PlayListSource.SequentialSelector.IsLoop}">
+                        <ToggleButton.Content>
+                            <TextBlock
+                                Margin="8,0"
+                                Foreground="Black"
+                                Text="Loop" />
+                        </ToggleButton.Content>
+                    </ToggleButton>
+
+                    <TextBlock VerticalAlignment="Center" Text="Vol :" />
+                    <TextBlock
+                        Width="25"
+                        VerticalAlignment="Center"
+                        Text="{Binding PlaybackControlViewmodel.Volume, Converter={StaticResource VolumePercentageConverter}}"
+                        TextAlignment="Center" />
+                    <Border Margin="5,0" />
+                    <Slider
+                        Width="250"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Center"
+                        Maximum="1.0"
+                        Minimum="0"
+                        Ticks="0.01"
+                        Value="{Binding PlaybackControlViewmodel.Volume}">
+                        <Slider.Style>
+                            <Style TargetType="Slider">
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding PlaybackControlViewmodel.PlayingStatus}" Value="{x:Static models:PlayingStatus.Fading}">
+                                        <Setter Property="IsEnabled" Value="False" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Slider.Style>
+                    </Slider>
+                </StackPanel>
+
+                <Border
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    Grid.ColumnSpan="2"
+                    HorizontalAlignment="Stretch"
+                    Background="LightSteelBlue">
+                    <StackPanel>
+                        <StackPanel Margin="4" Orientation="Horizontal">
+
+                            <StackPanel.Resources>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Foreground" Value="Black" />
+                                    <Setter Property="FontSize" Value="{StaticResource BasicFontSize}" />
+                                </Style>
+                            </StackPanel.Resources>
+
+                            <TextBlock Text="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.PlayingFileName}" />
+                            <TextBlock Margin="4,0" Text="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.PlaybackTimeString}" />
+                        </StackPanel>
+
+                        <controls:MetroProgressBar
+                            Height="3"
+                            Maximum="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.CurrentSoundLength}"
+                            Minimum="0"
+                            Value="{Binding PlaybackControlViewmodel.PlaybackInformationViewer.CurrentSoundPosition}" />
+                    </StackPanel>
+                </Border>
+            </Grid>
+        </Border>
 
     </Grid>
 </controls:MetroWindow>


### PR DESCRIPTION
 - 外観
     - 視聴履歴パネルに、サウンドのディレクトリパスを表示
     - 再生コントロールエリアの上辺にボーダーを追加
     - 再生ファイル名エリアの背景色をグラデーションに変更